### PR TITLE
Fix: Seasons not being extracted correctly from request

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each rule is divided into `match` and `apply` sections:
 #### Apply Section
 - `root_folder`: The directory where the media should be stored if the rule is applied. Required.
 - `server_id`: The ID of the server where the media is hosted. Refer to the drop-down selection on a request in Overseerr, starting from 0. This number corresponds to the server selection. Required.
+   - NOTE: "Hidden" servers, such as a 4K server in a non-4K request, are included in the count. Adjust appropriately. 
 - `quality_profile_id`: The ID of the quality profile to apply to the request. This ID also starts from 0 and corresponds to the selection in a quality profile drop-down in Overseerr. Optional (will default to default quality profile).
 - `approve`: Whether to automatically approve this request (`true` or `false`). Required.
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To enable Rerouterr to handle requests, you need to set up a webhook in Overseer
              "requestedBy_username": "{{requestedBy_username}}",
              "requestedBy_avatar": "{{requestedBy_avatar}}"
          },
-         "extra": []
+         "{{extra}}": []
      }
      ```
    - **Notification Type**: Choose "Request Pending Approval".

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ async function processRequest(request_data) {
 
 // Determine applicable rule based on the request data
 function determinePutData(request_data) {
-    const { media, extra = [] } = request_data;
+    const { media, extra } = request_data;
     
     for (const rule of config.rules) {
         if (media.media_type === rule.media_type && matchRule(media, rule.match || {})) {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ async function processRequest(request_data) {
         const response_data = response.data;
 
         // Update the media object with the fetched details
-        console.log(request_data)
+        console.log(response_data)
         request_data.media.genres = response_data.genres || [];
         request_data.media.keywords = response_data.keywords || [];
         logger.info(`Proccessing Request...\nMedia Type: ${media_type}\nRequest ID: ${request_data.request.request_id}\nName: ${response_data.name}`)

--- a/index.js
+++ b/index.js
@@ -41,18 +41,18 @@ async function processRequest(request_data) {
     const media_type = request_data.media.media_type;
     const media_tmdbid = request_data.media.tmdbId;
     const get_url = `/api/v1/${media_type}/${media_tmdbid}?language=en`;
-    
+
     try {
         const response = await axiosInstance.get(get_url);
         const response_data = response.data;
 
         // Update the media object with the fetched details
-        console.log(response_data)
+        console.log(request_data)
         request_data.media.genres = response_data.genres || [];
         request_data.media.keywords = response_data.keywords || [];
         logger.info(`Proccessing Request...\nMedia Type: ${media_type}\nRequest ID: ${request_data.request.request_id}\nName: ${response_data.name}`)
         const [putData, rule, approve] = determinePutData(request_data);
-        
+
         if (putData) {
             logger.info(`Rule matched: ${JSON.stringify(rule)}`);
             await applyConfiguration(request_data.request.request_id, putData, approve);
@@ -68,8 +68,8 @@ async function processRequest(request_data) {
 
 // Determine applicable rule based on the request data
 function determinePutData(request_data) {
-    const { media, extra } = request_data;
-    
+    const { media, extra = [] } = request_data;
+
     for (const rule of config.rules) {
         if (media.media_type === rule.media_type && matchRule(media, rule.match || {})) {
             const putData = {
@@ -83,8 +83,8 @@ function determinePutData(request_data) {
             }
 
             if (media.media_type === 'tv') {
-                const seasons = extra.filter(item => item.name === 'Requested Seasons').map(item => parseInt(item.value));
-                if (seasons.length) {
+                const seasons = extra.find(item => item.name === 'Requested Seasons').value.split(",").map(item => parseInt(item))
+                if (seasons.length > 0) {
                     putData['seasons'] = seasons;
                 }
             }


### PR DESCRIPTION
Trying to add any show or anime threw a http 500 error. This was caused by two things:

1. The webhook payload always returned empty `extra`. I fixed it per [Overseerr docs](https://docs.overseerr.dev/using-overseerr/notifications/webhooks#special). It now looks like this in the request:
`extra: [ { name: 'Requested Seasons', value: '1, 2, 3, 4, 5' } ]`

2. The filter function didn't return all season numbers.
E.g:  `{  name: 'Requested Seasons',  value:  '1, 2, 3, 4, 5'  }` returned `[1]`. 
I adjusted it so now, using the above input, it returns `[1, 2, 3, 4, 5]` as expected.

These tweaks fixed the error for me.

I also added a note in the READ.ME about hidden servers. Basically I have three servers - Default, 4K and Anime. Going by the READ.ME, someone (me) might think that since the 4K server doesn't show in the dropdown it's not included in the id count. But it is.
![image](https://github.com/user-attachments/assets/2b0cc9a0-d1d3-4436-974f-f0f8dab8528b)
Here the ids are as follows: `Movies (Default): 0, 4K (hidden): 1, Movies (Anime): 2`
I'm not good with words so please adjust this note. Or don't include it at all.

Thanks for the great script! :)






 